### PR TITLE
Adding script for regenerator runtime.

### DIFF
--- a/lib/standalone-single-spa.js
+++ b/lib/standalone-single-spa.js
@@ -145,6 +145,15 @@ class StandaloneSingleSpaPlugin {
       voidTag: false,
       attributes: {
         defer: false,
+        src:
+          "https://cdn.jsdelivr.net/npm/regenerator-runtime@0.13.7/runtime.min.js",
+      },
+    });
+    scripts.push({
+      tagName: "script",
+      voidTag: false,
+      attributes: {
+        defer: false,
         src: "https://cdn.jsdelivr.net/npm/systemjs/dist/system.js",
       },
     });

--- a/test/__snapshots__/standalone-single-spa.test.js.snap
+++ b/test/__snapshots__/standalone-single-spa.test.js.snap
@@ -26,6 +26,8 @@ exports[`standalone-single-spa-webpack-plugin basic-parcel 1`] = `
   }
 }
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/regenerator-runtime@0.13.7/runtime.min.js">
+    </script>
     <script src="https://cdn.jsdelivr.net/npm/systemjs/dist/system.js">
     </script>
     <script src="https://cdn.jsdelivr.net/npm/systemjs/dist/extras/amd.js">
@@ -69,6 +71,8 @@ exports[`standalone-single-spa-webpack-plugin basic-usage 1`] = `
     "foo": "/foo.js"
   }
 }
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/regenerator-runtime@0.13.7/runtime.min.js">
     </script>
     <script src="https://cdn.jsdelivr.net/npm/systemjs/dist/system.js">
     </script>


### PR DESCRIPTION
See the following code where we set `regenerator: false`, which means that the bundles expect `window.regeneratorRuntime` to be defined. Adding the script here defines that variable so that bundles that use async+await or generators work.

https://github.com/single-spa/create-single-spa/blob/147d2878d8ab50d442b617c702d7cce6e45ce481/packages/generator-single-spa/src/common-templates/babel.config.json.ejs#L12