### PR TITLE
Add import-map-overrides, including UI.

### DIFF
--- a/lib/standalone-single-spa.js
+++ b/lib/standalone-single-spa.js
@@ -160,6 +160,9 @@ class StandaloneSingleSpaPlugin {
     scripts.push({
       tagName: "import-map-overrides-full",
       voidTag: false,
+      attributes: {
+        "dev-libs": true,
+      },
     });
     scripts.push({
       tagName: "script",

--- a/lib/standalone-single-spa.js
+++ b/lib/standalone-single-spa.js
@@ -141,6 +141,27 @@ class StandaloneSingleSpaPlugin {
       innerHTML: JSON.stringify(importMap, null, 2),
     });
     scripts.push({
+      tagName: "meta",
+      voidTag: true,
+      attributes: {
+        name: "importmap-type",
+        content: "systemjs-importmap",
+      },
+    });
+    scripts.push({
+      tagName: "script",
+      voidTag: false,
+      attributes: {
+        defer: false,
+        src:
+          "https://cdn.jsdelivr.net/npm/import-map-overrides/dist/import-map-overrides.js",
+      },
+    });
+    scripts.push({
+      tagName: "import-map-overrides-full",
+      voidTag: false,
+    });
+    scripts.push({
       tagName: "script",
       voidTag: false,
       attributes: {

--- a/lib/standalone-single-spa.js
+++ b/lib/standalone-single-spa.js
@@ -18,6 +18,7 @@ const defaultOptions = {
   importMap: { imports: {} },
   disabled: false,
   HtmlWebpackPlugin,
+  importMapOverrides: true,
 };
 
 class StandaloneSingleSpaPlugin {
@@ -35,6 +36,8 @@ class StandaloneSingleSpaPlugin {
    * importMap?: ImportMap;
    * isParcel?: boolean;
    * disabled?: boolean;
+   * importMapOverrides?: boolean;
+   * importMapOverridesLocalStorageKey?: string;
    * HtmlWebpackPlugin?: any;
    * }} options
    */
@@ -148,22 +151,33 @@ class StandaloneSingleSpaPlugin {
         content: "systemjs-importmap",
       },
     });
-    scripts.push({
-      tagName: "script",
-      voidTag: false,
-      attributes: {
-        defer: false,
-        src:
-          "https://cdn.jsdelivr.net/npm/import-map-overrides/dist/import-map-overrides.js",
-      },
-    });
-    scripts.push({
-      tagName: "import-map-overrides-full",
-      voidTag: false,
-      attributes: {
+    if (this.options.importMapOverrides) {
+      scripts.push({
+        tagName: "script",
+        voidTag: false,
+        attributes: {
+          defer: false,
+          src:
+            "https://cdn.jsdelivr.net/npm/import-map-overrides/dist/import-map-overrides.js",
+        },
+      });
+
+      const imoUIAttrs = {
         "dev-libs": true,
-      },
-    });
+      };
+
+      if (this.options.importMapOverridesLocalStorageKey) {
+        imoUIAttrs[
+          "show-when-local-storage"
+        ] = this.options.importMapOverridesLocalStorageKey;
+      }
+
+      scripts.push({
+        tagName: "import-map-overrides-full",
+        voidTag: false,
+        attributes: imoUIAttrs,
+      });
+    }
     scripts.push({
       tagName: "script",
       voidTag: false,

--- a/lib/standalone-single-spa.js
+++ b/lib/standalone-single-spa.js
@@ -19,6 +19,7 @@ const defaultOptions = {
   disabled: false,
   HtmlWebpackPlugin,
   importMapOverrides: true,
+  importMapOverridesLocalStorageKey: null,
 };
 
 class StandaloneSingleSpaPlugin {

--- a/test/__snapshots__/standalone-single-spa.test.js.snap
+++ b/test/__snapshots__/standalone-single-spa.test.js.snap
@@ -24,6 +24,13 @@ exports[`standalone-single-spa-webpack-plugin basic-parcel 1`] = `
   }
 }
     </script>
+    <meta name="importmap-type"
+          content="systemjs-importmap"
+    >
+    <script src="https://cdn.jsdelivr.net/npm/import-map-overrides/dist/import-map-overrides.js">
+    </script>
+    <import-map-overrides-full>
+    </import-map-overrides-full>
     <script src="https://cdn.jsdelivr.net/npm/regenerator-runtime@0.13.7/runtime.min.js">
     </script>
     <script src="https://cdn.jsdelivr.net/npm/systemjs/dist/system.js">
@@ -70,6 +77,13 @@ exports[`standalone-single-spa-webpack-plugin basic-usage 1`] = `
   }
 }
     </script>
+    <meta name="importmap-type"
+          content="systemjs-importmap"
+    >
+    <script src="https://cdn.jsdelivr.net/npm/import-map-overrides/dist/import-map-overrides.js">
+    </script>
+    <import-map-overrides-full>
+    </import-map-overrides-full>
     <script src="https://cdn.jsdelivr.net/npm/regenerator-runtime@0.13.7/runtime.min.js">
     </script>
     <script src="https://cdn.jsdelivr.net/npm/systemjs/dist/system.js">

--- a/test/__snapshots__/standalone-single-spa.test.js.snap
+++ b/test/__snapshots__/standalone-single-spa.test.js.snap
@@ -29,7 +29,7 @@ exports[`standalone-single-spa-webpack-plugin basic-parcel 1`] = `
     >
     <script src="https://cdn.jsdelivr.net/npm/import-map-overrides/dist/import-map-overrides.js">
     </script>
-    <import-map-overrides-full>
+    <import-map-overrides-full dev-libs>
     </import-map-overrides-full>
     <script src="https://cdn.jsdelivr.net/npm/regenerator-runtime@0.13.7/runtime.min.js">
     </script>
@@ -82,7 +82,7 @@ exports[`standalone-single-spa-webpack-plugin basic-usage 1`] = `
     >
     <script src="https://cdn.jsdelivr.net/npm/import-map-overrides/dist/import-map-overrides.js">
     </script>
-    <import-map-overrides-full>
+    <import-map-overrides-full dev-libs>
     </import-map-overrides-full>
     <script src="https://cdn.jsdelivr.net/npm/regenerator-runtime@0.13.7/runtime.min.js">
     </script>

--- a/test/__snapshots__/standalone-single-spa.test.js.snap
+++ b/test/__snapshots__/standalone-single-spa.test.js.snap
@@ -110,3 +110,107 @@ exports[`standalone-single-spa-webpack-plugin basic-usage 1`] = `
   </body>
 </html>
 `;
+
+exports[`standalone-single-spa-webpack-plugin disabled import-map-overrides 1`] = `
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>
+      Webpack App
+    </title>
+    <meta name="viewport"
+          content="width=device-width,initial-scale=1"
+    >
+    <script type="systemjs-importmap">
+      {
+  "imports": {
+    "single-spa": "https://cdn.jsdelivr.net/npm/single-spa/lib/system/single-spa.dev.js",
+    "basic-usage": "/main.js"
+  }
+}
+    </script>
+    <meta name="importmap-type"
+          content="systemjs-importmap"
+    >
+    <script src="https://cdn.jsdelivr.net/npm/regenerator-runtime@0.13.7/runtime.min.js">
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/systemjs/dist/system.js">
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/systemjs/dist/extras/amd.js">
+    </script>
+    <script>
+      System.import('single-spa').then(function (singleSpa) {
+  singleSpa.registerApplication({
+    name: 'basic-usage',
+    app: function () {
+      return System.import('basic-usage');
+    },
+    activeWhen: ["/"]
+  });
+  if (!window.location.pathname.startsWith('/')) {
+    singleSpa.navigateToUrl('/');
+  }
+  singleSpa.start();
+});
+    </script>
+  </head>
+  <body>
+  </body>
+</html>
+`;
+
+exports[`standalone-single-spa-webpack-plugin import-map-overrides with local storage key 1`] = `
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>
+      Webpack App
+    </title>
+    <meta name="viewport"
+          content="width=device-width,initial-scale=1"
+    >
+    <script type="systemjs-importmap">
+      {
+  "imports": {
+    "single-spa": "https://cdn.jsdelivr.net/npm/single-spa/lib/system/single-spa.dev.js",
+    "basic-usage": "/main.js"
+  }
+}
+    </script>
+    <meta name="importmap-type"
+          content="systemjs-importmap"
+    >
+    <script src="https://cdn.jsdelivr.net/npm/import-map-overrides/dist/import-map-overrides.js">
+    </script>
+    <import-map-overrides-full dev-libs
+                               show-when-local-storage="devtools"
+    >
+    </import-map-overrides-full>
+    <script src="https://cdn.jsdelivr.net/npm/regenerator-runtime@0.13.7/runtime.min.js">
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/systemjs/dist/system.js">
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/systemjs/dist/extras/amd.js">
+    </script>
+    <script>
+      System.import('single-spa').then(function (singleSpa) {
+  singleSpa.registerApplication({
+    name: 'basic-usage',
+    app: function () {
+      return System.import('basic-usage');
+    },
+    activeWhen: ["/"]
+  });
+  if (!window.location.pathname.startsWith('/')) {
+    singleSpa.navigateToUrl('/');
+  }
+  singleSpa.start();
+});
+    </script>
+  </head>
+  <body>
+  </body>
+</html>
+`;

--- a/test/standalone-single-spa.test.js
+++ b/test/standalone-single-spa.test.js
@@ -98,6 +98,52 @@ describe("standalone-single-spa-webpack-plugin", () => {
     const html = await readOutputHtml(outputDir);
     expect(html.includes("systemjs")).toBe(false);
   });
+
+  test("disabled import-map-overrides", async () => {
+    const outputDir = path.resolve(__dirname, "./output/basic-usage");
+
+    const config = {
+      entry: path.resolve(__dirname, "./fixtures/basic/index.js"),
+      output: {
+        libraryTarget: "system",
+        path: outputDir,
+      },
+      plugins: [
+        new HtmlWebpackPlugin(),
+        new StandalonePlugin({
+          appOrParcelName: "basic-usage",
+          importMapOverrides: false,
+        }),
+      ],
+    };
+
+    const stats = await webpackCompile(config);
+    const html = await readOutputHtml(outputDir);
+    expect(html).toMatchSnapshot();
+  });
+
+  test("import-map-overrides with local storage key", async () => {
+    const outputDir = path.resolve(__dirname, "./output/basic-usage");
+
+    const config = {
+      entry: path.resolve(__dirname, "./fixtures/basic/index.js"),
+      output: {
+        libraryTarget: "system",
+        path: outputDir,
+      },
+      plugins: [
+        new HtmlWebpackPlugin(),
+        new StandalonePlugin({
+          appOrParcelName: "basic-usage",
+          importMapOverridesLocalStorageKey: "devtools",
+        }),
+      ],
+    };
+
+    const stats = await webpackCompile(config);
+    const html = await readOutputHtml(outputDir);
+    expect(html).toMatchSnapshot();
+  });
 });
 
 function webpackCompile(config) {


### PR DESCRIPTION
When working with a client, they had a desire to add new modules and import maps via import-map-overrides when using the standalone plugin. Adding import-map-overrides here will make it easier for them because they won't have to configure each MFE to have import-map-overrides. I also think that the change could end up being useful for other organizations, too